### PR TITLE
Reduce horizontal page scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>HTML Sanitizer API Playground</title>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;800&family=Roboto+Slab:wght@100;500&display=swap" rel="stylesheet" crossorigin="anonymous">
-  <link href="/style.css" rel="stylesheet">
+  <link href="style.css" rel="stylesheet">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@mikewest">
@@ -22,7 +22,7 @@
       sanitizes an untrusted string, minimizing the risk of unintended script execution. Amazing,
       right?
     </p>
- 
+
     <h2>Untrusted Input</h2>
     <textarea id="input">&lt;p&gt;
   This is a very boring string that
@@ -36,7 +36,7 @@
     <p><a href="#" id="permalink">Link to this input.</a></p>
 
     <h2>Live Output</h2>
-    
+
     <p><strong>Configuration: </strong><code>new Sanitizer(</code><select id="config">
       <option value="empty">{}</option>
       <option value="no-attributes">{ "allowAttributes": [] }</option>
@@ -85,7 +85,7 @@ el.replaceChildren(s.sanitize(<em>untrustedInput</em>));</code></pre>
       p.textContent = "This browser doesn't appear to support the `Sanitizer` interface; nothing below will do much... Try Chrome Canary with `chrome://flags/#enable-experimental-web-platform-features` enabled? Or Firefox Nightly with `dom.security.sanitizer.enabled` set to true?";
       document.querySelector('p').before(p);
     }
-   
+
     // Exciting constant element references!
     const input = document.querySelector('#input');
     const outputDiv = document.querySelector('#output');
@@ -103,7 +103,7 @@ el.replaceChildren(s.sanitize(<em>untrustedInput</em>));</code></pre>
     document.querySelector('#inject').addEventListener('click', _ => {
       outputDiv.innerHTML = input.value;
     });
-   
+
     // Register updater for <textarea> input and <select> changes:
     function update() {
       // Update the permalink:

--- a/style.css
+++ b/style.css
@@ -22,6 +22,9 @@ p, ul {
   font: 18px/1.2 'Open Sans', sans-serif;
 }
 
+select {
+  max-width: 100%;
+}
 #input {
   display: block;
   width: 100%;
@@ -41,6 +44,7 @@ p, ul {
 
 #output, output {
   width: 750px;
+  max-width: 100%;
   min-height: 200px;
   box-sizing: border-box;
   border-radius: 8px;
@@ -93,5 +97,7 @@ pre {
   border: 0 solid #E0CB52;
   border-width: 0 0 0 0.5em;
   color: #555;
+  white-space: pre;
+  overflow: auto;
 }
   pre strong { color: #000; }


### PR DESCRIPTION
This patch makes the site support viewports as narrow as 311px without any horizontal page scrolling. The individual `<pre>`s now have their own scrollbars, however, but overall that’s a better user experience IMHO.