### PR TITLE
Repair `textarea` readonly

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,11 @@ el.setHTML(<em>untrustedInput</em>, {sanitizer: <strong><em>s</em></strong>});</
         configUse.textContent = "";
         configText.readOnly = true;
         configText.value = '"default"';
-      }  else {
+      } else if (config === "custom") {
+        configOther.className = "";
+        configText.readOnly = false;
+        configUse.textContent = "config";
+      } else {
         createConf.className = "";
         useConf.className = "";
         setWithoutConf.className = "invisible";


### PR DESCRIPTION
The `textarea` was not writable for custom configurations,
because we were missing the crucial `readOnly = false` assignment
and the corresponding conditional branch.
